### PR TITLE
chore: used localhost as samples and redirect to servers page for reference

### DIFF
--- a/pages/dotnet.mdx
+++ b/pages/dotnet.mdx
@@ -16,20 +16,25 @@ dotnet add package Utxorpc.Sdk
 Here’s how you can start using the `SyncServiceClient` to interact with the UTxORPC.
 
 #### 1. Initialize the Client
+The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
 
+For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+
+Here's how to initialize the client:
 ```csharp
 using Utxorpc.Sdk;
 
 var headers = new Dictionary<string, string>
 {
-    { "dmtr-api-key", "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6" },
+    { "api-key", "" },
 };
 
 var client = new SyncServiceClient(
-    url: "https://preview.utxorpc-v0.demeter.run",
+    url: "http://localhost:50051",
     headers
 );
 ```
+This sample is structured in a way that can be used if your UTxORPC node comes from a provider and you need to attach needed information to your header.
 
 #### 2. Follow the Tip of the Blockchain
 

--- a/pages/nodejs.mdx
+++ b/pages/nodejs.mdx
@@ -27,6 +27,10 @@ The SDK provides three primary clients for interacting with UTxORPC:
 
 ## Usage
 
+The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
+
+For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+
 Below are examples of how to use each of the clients in the SDK.
 
 ### 1. CardanoSyncClient
@@ -40,10 +44,7 @@ import { CardanoSyncClient } from "@utxorpc/sdk";
 
 async function followTipExample() {
   const syncClient = new CardanoSyncClient({
-    uri: "https://preview.utxorpc-v0.demeter.run",
-    headers: {
-      "dmtr-api-key": "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6"
-    }
+    uri: "http://localhost:50051"
   });
 
   const tip = syncClient.followTip([
@@ -68,10 +69,7 @@ import { CardanoSyncClient } from "@utxorpc/sdk";
 
 async function fetchBlockExample() {
   const syncClient = new CardanoSyncClient({
-    uri: "https://preview.utxorpc-v0.demeter.run",
-    headers: {
-      "dmtr-api-key": "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6"
-    }
+    uri: "http://localhost:50051"
   });
 
   const block = await syncClient.fetchBlock({
@@ -96,10 +94,7 @@ import { CardanoQueryClient } from "@utxorpc/sdk";
 
 async function readParamsExample() {
   const queryClient = new CardanoQueryClient({
-    uri: "https://preview.utxorpc-v0.demeter.run",
-    headers: {
-      "dmtr-api-key": "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6"
-    }
+    uri: "http://localhost:50051"
   });
 
   const params = await queryClient.readParams();
@@ -116,10 +111,7 @@ import { CardanoQueryClient } from "@utxorpc/sdk";
 
 async function searchUtxosByAddressExample() {
   const queryClient = new CardanoQueryClient({
-    uri: "https://preview.utxorpc-v0.demeter.run",
-    headers: {
-      "dmtr-api-key": "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6"
-    }
+    uri: "http://localhost:50051"
   });
 
   const utxos = await queryClient.searchUtxosByAddress(
@@ -145,10 +137,7 @@ import { CardanoSubmitClient } from "@utxorpc/sdk";
 
 async function submitTxExample() {
   const submitClient = new CardanoSubmitClient({
-    uri: "https://preview.utxorpc-v0.demeter.run",
-    headers: {
-      "dmtr-api-key": "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6"
-    }
+    uri: "http://localhost:50051"
   });
 
   const txSample = "84a300d90102818258203dc5d9977e7b3d51acaea81031d2f461404536b2828549b73876a5980295f81b00018282581d60916c769efc6e2a3339594818a1d0c3998c29e3a6303d8711de8567591a004c4b4082581d60916c769efc6e2a3339594818a1d0c3998c29e3a6303d8711de8567591b0000000253bcffb3021a0002990da100d9010281825820526fa19e3694cda4f3c0d2fb2d2bb8768925eccc49a89d5f12b1972644ac769858403d6d6599193b17e67827cd9f48aaf35ac762c6fb0c5402c52724f307b69ff96f3f7e6c3fb107670c28679c148bf510f479c01a34b9d95d0dbb7e4ff6f3cb560af5f6";


### PR DESCRIPTION
**Summary:**
- **Tweaked Documentation for Node and .NET sdk:** Now uses localhost in samples instead of previous Demeter UTxORPC compatible nodes.

- **Added Redirection to Servers page in sdk docs** Included a link to redirect into Servers page as context for UTxORPC compatible nodes that users can use.


