### PR TITLE
fix: fixed header logo path and enhanced documentations

### DIFF
--- a/pages/blaze.mdx
+++ b/pages/blaze.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Blaze UTxORPC Provider 
 
 This provides instructions on using the **UTxORPC (u5c)** provider for the [Blaze](https://github.com/butaneprotocol/blaze-cardano) library. 
@@ -47,9 +49,11 @@ import { U5C } from "@utxorpc/blaze-provider";
 ```
 
 ### Step 2: Create a New U5C Provider
-The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
-
-For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+<Callout type="note">
+    The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
+    
+    For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+</Callout>
 
 Here's how to create the U5C Provider:
 ```javascript

--- a/pages/deno.mdx
+++ b/pages/deno.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Deno with Node.js SDK
 
 The UTxORPC SDK, an npm package for interacting with UTxORPC-compatible nodes, is also compatible with Deno thanks to the latest 'Deno 2' update. This allows you to fetch blocks, submit transactions, and synchronize with the latest blocks seamlessly using Deno's now native npm package support.
@@ -63,9 +65,11 @@ The SDK includes three primary clients for interacting with UTxORPC nodes:
 
 ## Usage
 
-The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
-
-For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+<Callout type="note">
+    The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
+    
+    For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+</Callout>
 
 Below are examples of how to use each of the clients in the SDK.
 
@@ -118,7 +122,7 @@ fetchBlockExample().catch(console.error);
 
 ### 2. CardanoQueryClient
 
-`CardanoQueryClient` lets you query blockchain data, read protocol parameters, and search UTXOs.
+`CardanoQueryClient` lets you query blockchain data, read protocol parameters, and search UTxOs.
 
 #### Example: Reading Blockchain Parameters
 
@@ -137,7 +141,7 @@ async function readParamsExample() {
 readParamsExample().catch(console.error);
 ```
 
-#### Example: Searching UTXOs by Address
+#### Example: Searching UTxOs by Address
 
 ```typescript
 import { CardanoQueryClient } from "npm:@utxorpc/sdk";

--- a/pages/dotnet.mdx
+++ b/pages/dotnet.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 ## .NET SDK
 
 ### Overview
@@ -12,13 +14,15 @@ dotnet add package Utxorpc.Sdk
 ```
 
 ### Getting Started
+<Callout type="note">
+    The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
+    
+    For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+</Callout>
 
 Here’s how you can start using the `SyncServiceClient` to interact with the UTxORPC.
 
 #### 1. Initialize the Client
-The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
-
-For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
 
 Here's how to initialize the client:
 ```csharp

--- a/pages/nodejs.mdx
+++ b/pages/nodejs.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Node.js SDK
 
 This SDK allows you to interact with UTxORPC compatible nodes, enabling operations such as fetching blocks, submitting transactions, and syncing with the latest blocks.
@@ -27,9 +29,11 @@ The SDK provides three primary clients for interacting with UTxORPC:
 
 ## Usage
 
-The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
-
-For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+<Callout type="note">
+    The following code samples assume that the UTxORPC node is running locally on `localhost:50051`. If your node is hosted remotely or on a different server, replace `"http://localhost:50051"` with the appropriate server URL and port for your environment. 
+    
+    For more details on configuring your node, refer to the [UTxORPC Ecosystem Servers Documentation](/servers).
+</Callout>
 
 Below are examples of how to use each of the clients in the SDK.
 
@@ -85,7 +89,7 @@ fetchBlockExample().catch(console.error);
 
 ### 2. CardanoQueryClient
 
-The `CardanoQueryClient` allows you to query blockchain data, including reading protocol parameters and searching UTXOs.
+The `CardanoQueryClient` allows you to query blockchain data, including reading protocol parameters and searching UTxOs.
 
 #### Example: Reading Blockchain Parameters
 
@@ -104,7 +108,7 @@ async function readParamsExample() {
 readParamsExample().catch(console.error);
 ```
 
-#### Example: Searching UTXOs by Address
+#### Example: Searching UTxOs by Address
 
 ```javascript
 import { CardanoQueryClient } from "@utxorpc/sdk";
@@ -152,4 +156,4 @@ submitTxExample().catch(console.error);
 
 ## Conclusion
 
-This SDK is designed to streamline the process of interacting with UTxORPC using Node.js. Whether you're syncing with the latest blockchain data, querying UTXOs, or submitting transactions, this SDK provides the necessary tools to build robust blockchain applications with ease.
+This SDK is designed to streamline the process of interacting with UTxORPC using Node.js. Whether you're syncing with the latest blockchain data, querying UTxOs, or submitting transactions, this SDK provides the necessary tools to build robust blockchain applications with ease.

--- a/pages/query/intro.mdx
+++ b/pages/query/intro.mdx
@@ -6,6 +6,35 @@ import { Tabs, Tab } from 'nextra-theme-docs'
 
 The _Query_ module provides an interface for querying the state of the ledger with the main goal of constructing new transactions.
 
+## Sequence Example
+
+The following diagram describes the message exchange between a client and service where the client queries protocol parameters, reads UTxOs, and queries UTxOs.
+
+
+```mermaid
+%%{init: { 'theme': 'dark' } }%%
+sequenceDiagram
+  actor Client
+  participant QueryService
+
+  Note over Client,QueryService: query params to define fees / other criteria
+  Client->>+QueryService: ReadParams (field_mask)
+  QueryService-->>-Client: <param>[]
+
+  Note over Client,QueryService: read UTxO by ref to resolve tx inputs
+  Client->>+QueryService: ReadUtxos (refs)
+  QueryService-->>-Client: ReadUtxos (utxos)
+
+  Note over Client,QueryService: query UTxO by address to balance tx
+  Client->>+QueryService: SearchUtxos (address_pattern)
+  QueryService-->>-Client: SearchUtxos (utxos)
+
+  Note over Client,QueryService: query UTxO by token used as beacon
+  Client->>+QueryService: SearchUtxos (token_pattern)
+  QueryService-->>-Client: SearchUtxos (utxos)
+```
+
+
 ## Operations
 
 <Callout type="info">
@@ -33,7 +62,7 @@ Retrieves the current protocol parameters for the chain, including important val
 </Tabs>
 
 ### ReadUtxos 
-Fetches specific UTXOs by their transaction reference (hash and index). Useful when you need to look up known UTXOs directly.
+Fetches specific UTxOs by their output reference (hash and index). Useful when you need to look up known UTxOs directly.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -52,10 +81,10 @@ Fetches specific UTXOs by their transaction reference (hash and index). Useful w
 </Tabs>
 
 ### SearchUtxos
-Search for UTXOs using various filtering patterns. The following search methods are available:
+Search for UTxOs using various filtering patterns. The following search methods are available:
 
 #### By Address
-Search for all UTXOs controlled by a specific Cardano address. The address must be base64 encoded.
+Search for all UTxOs controlled by a specific Cardano address. The address must be base64 encoded.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -79,7 +108,7 @@ Search for all UTXOs controlled by a specific Cardano address. The address must 
 </Tabs>
 
 #### By Address Payment Part 
-Search for UTXOs by just the payment credential part of an address. Useful when you want to find UTXOs regardless of stake credential.
+Search for UTxOs by just the payment credential part of an address. Useful when you want to find UTxOs regardless of stake credential.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -103,7 +132,7 @@ Search for UTXOs by just the payment credential part of an address. Useful when 
 </Tabs>
 
 #### By Address Delegation Part
-Search for UTXOs by just the stake credential (delegation part) of an address. Helps find all UTXOs delegated to a specific stake key.
+Search for UTxOs by just the stake credential (delegation part) of an address. Helps find all UTxOs delegated to a specific stake key.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -127,7 +156,7 @@ Search for UTXOs by just the stake credential (delegation part) of an address. H
 </Tabs>
 
 #### By Asset Policy
-Search for UTXOs containing tokens from a specific policy ID. The policy ID must be base64 encoded.
+Search for UTxOs containing tokens from a specific policy ID. The policy ID must be base64 encoded.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -151,7 +180,7 @@ Search for UTXOs containing tokens from a specific policy ID. The policy ID must
 </Tabs>
 
 #### By Specific Asset 
-Search for UTXOs containing a specific token, identified by both policy ID and asset name (combined and base64 encoded).
+Search for UTxOs containing a specific token, identified by both policy ID and asset name (combined and base64 encoded).
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -177,7 +206,7 @@ Search for UTXOs containing a specific token, identified by both policy ID and a
 ### ReadData 
 Read specific data (plural of datum) by hash.
 <Callout type="warning">
-  This operation is yet to be implemented in Dolos and is still getting worked on.
+  This operation is currently under development in Dolos and is not yet available.
 </Callout>
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -198,28 +227,3 @@ Read specific data (plural of datum) by hash.
 <Callout type="info">
   The schema details can be found in the [spec reference](spec).
 </Callout>
-
-## Sequence Example
-
-```mermaid
-%%{init: { 'theme': 'dark' } }%%
-sequenceDiagram
-  actor Client
-  participant QueryService
-
-  Note over Client,QueryService: query params to define fees / other criteria
-  Client->>+QueryService: ReadParams (field_mask)
-  QueryService-->>-Client: <param>[]
-
-  Note over Client,QueryService: read UTxO by ref to resolve tx inputs
-  Client->>+QueryService: ReadUtxos (refs)
-  QueryService-->>-Client: ReadUtxos (utxos)
-
-  Note over Client,QueryService: query UTxO by address to balance tx
-  Client->>+QueryService: SearchUtxos (address_pattern)
-  QueryService-->>-Client: SearchUtxos (utxos)
-
-  Note over Client,QueryService: query UTxO by token used as beacon
-  Client->>+QueryService: SearchUtxos (token_pattern)
-  QueryService-->>-Client: SearchUtxos (utxos)
-```

--- a/pages/submit/intro.mdx
+++ b/pages/submit/intro.mdx
@@ -5,6 +5,29 @@ import { Tabs, Tab } from 'nextra-theme-docs'
 
 The _Submit_ module provides an interface for submitting transactions and monitoring their progress through various stages in their lifecycle.
 
+## Sequence Example
+
+The following diagram describes the message exchange between a client and service where the client submits a transaction and waits for status updates asynchrounously.
+
+```mermaid
+%%{init: { 'theme': 'dark' } }%%
+sequenceDiagram
+  actor Client
+  participant SubmitService
+  Client->>+SubmitService: Submit (Tx)
+  SubmitService-->>-Client: Tx Ref
+  Client->>SubmitService: Wait For (Tx Ref)
+  activate SubmitService
+  SubmitService--)Client: Tx Acknowledged
+  SubmitService--)Client: Tx in Mempool
+  SubmitService--)Client: Tx in Network
+  SubmitService--)Client: Tx Confirmed (1 block)
+  SubmitService--)Client: Tx Confirmed (2 block)
+  SubmitService--)Client: Tx Confirmed (n block)
+  Client->>SubmitService: Done
+  deactivate SubmitService
+```
+
 ## Operations
 
 <Callout type="info">
@@ -111,7 +134,7 @@ Watch mempool by just the stake credential (delegation part) of an address.
 </Tabs>
 
 #### By Asset Policy
-Watch mempool for UTXOs containing tokens from a specific policy ID. The policy ID must be base64 encoded.
+Watch mempool for UTxOs containing tokens from a specific policy ID. The policy ID must be base64 encoded.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -135,7 +158,7 @@ Watch mempool for UTXOs containing tokens from a specific policy ID. The policy 
 </Tabs>
 
 #### By Specific Asset
-Watch mempool for UTXOs containing a specific token, identified by both policy ID and asset name (combined and base64 encoded).
+Watch mempool for UTxOs containing a specific token, identified by both policy ID and asset name (combined and base64 encoded).
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -202,7 +225,7 @@ Evaluate transactions before submission to verify their validity and estimate ex
 Query the current state of the mempool to check status of pending transactions.
 
 <Callout type="warning">
-  This operation is yet to be implemented in Dolos and is still getting worked on.
+  This operation is currently under development in Dolos and is not yet available.
 </Callout>
 
 <Tabs items={['grpcurl']}>
@@ -219,25 +242,3 @@ Query the current state of the mempool to check status of pending transactions.
 <Callout type="info">
   The schema details can be found in the [spec reference](spec).
 </Callout>
-
-## Sequence Example
-
-The following diagram describes the message exchange between a client and service where the client submits a transaction and waits for status updates asynchrounously.
-
-```mermaid
-%%{init: { 'theme': 'dark' } }%%
-sequenceDiagram
-  actor Client
-  participant SubmitService
-  Client->>+SubmitService: Submit (Tx)
-  SubmitService-->>-Client: Tx Ref
-  Client->>SubmitService: Wait For (Tx Ref)
-  activate SubmitService
-  SubmitService--)Client: Tx Acknowledged
-  SubmitService--)Client: Tx in Mempool
-  SubmitService--)Client: Tx in Network
-  SubmitService--)Client: Tx Confirmed (1 block)
-  SubmitService--)Client: Tx Confirmed (2 block)
-  SubmitService--)Client: Tx Confirmed (n block)
-  Client->>SubmitService: Done
-  deactivate SubmitService

--- a/pages/sync/intro.mdx
+++ b/pages/sync/intro.mdx
@@ -5,6 +5,37 @@ import { Tabs, Tab } from 'nextra-theme-docs'
 
 The _Sync_ module provides an interface for synchronizing chain data, fetching blocks, and tracking the tip of the blockchain.
 
+## Sequence Example
+
+The following diagram describes the message exchange between a client and service where the client fetches a block, dumps history of chain, and streams the events from tip of the chain.
+
+```mermaid
+%%{init: { 'theme': 'dark' } }%%
+sequenceDiagram
+  actor Client
+  participant SyncService
+
+  Note over Client,SyncService: fetch a particular block
+  Client->>+SyncService: FetchBlock (<ref>)
+  SyncService-->>-Client: <block>
+
+  Note over Client,SyncService: dump history of chain in chunks of 100 blocks
+  Client->>+SyncService: DumpHistory (origin, 100)
+  SyncService-->>-Client: <block>[origin..100]
+
+  Client->>+SyncService: DumpHistory (last_ref, 100)
+  SyncService-->>-Client: <block>[101..200]
+
+  Note over Client,SyncService: stream change events from tip of the chain
+  Client->>SyncService: FollowTip (<intersection>)
+  activate SyncService
+  SyncService-->>Client: <apply>(block)
+  SyncService-->>Client: <undo>(block)
+  SyncService-->>Client: <reset>(point)
+  Client->>SyncService: Done
+  deactivate SyncService
+```
+
 ## Operations
 <Callout type="info">
   **Important**: All byte fields in grpcurl examples (like hashes, addresses, assets) must be base64 encoded.
@@ -67,7 +98,7 @@ Follow the blockchain tip with streaming updates.
 Get the current blockchain tip information.
 
 <Callout type="warning">
-  This operation is yet to be implemented in Dolos and is still getting worked on.
+  This operation is currently under development in Dolos and is not yet available.
 </Callout>
 
 <Tabs items={['grpcurl']}>
@@ -84,31 +115,3 @@ Get the current blockchain tip information.
 <Callout type="info">
   The schema details can be found in the [spec reference](spec).
 </Callout>
-
-## Sequence Example
-
-```mermaid
-%%{init: { 'theme': 'dark' } }%%
-sequenceDiagram
-  actor Client
-  participant SyncService
-
-  Note over Client,SyncService: fetch a particular block
-  Client->>+SyncService: FetchBlock (<ref>)
-  SyncService-->>-Client: <block>
-
-  Note over Client,SyncService: dump history of chain in chunks of 100 blocks
-  Client->>+SyncService: DumpHistory (origin, 100)
-  SyncService-->>-Client: <block>[origin..100]
-
-  Client->>+SyncService: DumpHistory (last_ref, 100)
-  SyncService-->>-Client: <block>[101..200]
-
-  Note over Client,SyncService: stream change events from tip of the chain
-  Client->>SyncService: FollowTip (<intersection>)
-  activate SyncService
-  SyncService-->>Client: <apply>(block)
-  SyncService-->>Client: <undo>(block)
-  SyncService-->>Client: <reset>(point)
-  Client->>SyncService: Done
-  deactivate SyncService

--- a/pages/watch/intro.mdx
+++ b/pages/watch/intro.mdx
@@ -5,6 +5,50 @@ import { Tabs, Tab } from 'nextra-theme-docs'
 
 The _Watch_ module provides an interface for streaming transactions based on specified predicates, allowing clients to monitor specific aspects of the blockchain.
 
+## Sequence Example
+
+The following diagram describes the message exchange between a client and service where the client watches transactions with a specific addresss, UTxO, asset, or datum.
+
+```mermaid
+%%{init: { 'theme': 'dark' } }%%
+sequenceDiagram
+  actor Client
+  participant WatchService
+
+  note over Client,WatchService: watch txs involved with specific address
+  Client->>WatchService: WatchTx (addr1xxx)
+  activate WatchService
+  WatchService--)Client: <apply>(tx with input from addr1xxx)
+  WatchService--)Client: <apply>(tx with output to addr1xxx)
+  Client->>WatchService: Done
+  deactivate WatchService
+
+  note over Client,WatchService: watch txs involved with specific utxo
+  Client->>WatchService: WatchTx (tx hash, tx output index)
+  activate WatchService
+  WatchService--)Client: <apply>(tx with matching input)
+  Client->>WatchService: Done
+  deactivate WatchService
+
+
+  note over Client,WatchService: watch txs involved with specific asset
+  Client->>WatchService: WatchTx (asset policy, asset name)
+  activate WatchService
+  WatchService--)Client: <apply>(tx with asset mint)
+  WatchService--)Client: <apply>(tx with asset in output)
+  WatchService--)Client: <apply>(tx with asset in input)
+  Client->>WatchService: Done
+  deactivate WatchService
+
+  note over Client,WatchService: watch txs involved with specific datum
+  Client->>WatchService: WatchTx (datum hash)
+  activate WatchService
+  WatchService--)Client: <apply>(tx with inline datum)
+  WatchService--)Client: <apply>(tx with redeemer datum)
+  Client->>WatchService: Done
+  deactivate WatchService
+```
+
 ## Operations
 <Callout type="info">
   **Important**: All byte fields in grpcurl examples (like hashes, addresses, assets) must be base64 encoded.
@@ -44,7 +88,7 @@ Watch all tx controlled by a specific Cardano address. The address must be base6
 </Tabs>
 
 #### By Address Payment Part
-Watch tx by just the payment credential part of an address. Useful when you want to find UTXOs regardless of stake credential.
+Watch tx by just the payment credential part of an address. Useful when you want to find UTxOs regardless of stake credential.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -68,7 +112,7 @@ Watch tx by just the payment credential part of an address. Useful when you want
 </Tabs>
 
 #### By Address Delegation Part
-Watch tx by just the stake credential (delegation part) of an address. Helps find all UTXOs delegated to a specific stake key.
+Watch tx by just the stake credential (delegation part) of an address. Helps find all UTxOs delegated to a specific stake key.
 
 <Tabs items={['grpcurl']}>
   <Tab>
@@ -142,44 +186,3 @@ Watch tx containing a specific token, identified by both policy ID and asset nam
 <Callout type="info">
   The schema details can be found in the [spec reference](spec).
 </Callout>
-
-## Sequence Example
-
-```mermaid
-%%{init: { 'theme': 'dark' } }%%
-sequenceDiagram
-  actor Client
-  participant WatchService
-
-  note over Client,WatchService: watch txs involved with specific address
-  Client->>WatchService: WatchTx (addr1xxx)
-  activate WatchService
-  WatchService--)Client: <apply>(tx with input from addr1xxx)
-  WatchService--)Client: <apply>(tx with output to addr1xxx)
-  Client->>WatchService: Done
-  deactivate WatchService
-
-  note over Client,WatchService: watch txs involved with specific utxo
-  Client->>WatchService: WatchTx (tx hash, tx output index)
-  activate WatchService
-  WatchService--)Client: <apply>(tx with matching input)
-  Client->>WatchService: Done
-  deactivate WatchService
-
-
-  note over Client,WatchService: watch txs involved with specific asset
-  Client->>WatchService: WatchTx (asset policy, asset name)
-  activate WatchService
-  WatchService--)Client: <apply>(tx with asset mint)
-  WatchService--)Client: <apply>(tx with asset in output)
-  WatchService--)Client: <apply>(tx with asset in input)
-  Client->>WatchService: Done
-  deactivate WatchService
-
-  note over Client,WatchService: watch txs involved with specific datum
-  Client->>WatchService: WatchTx (datum hash)
-  activate WatchService
-  WatchService--)Client: <apply>(tx with inline datum)
-  WatchService--)Client: <apply>(tx with redeemer datum)
-  Client->>WatchService: Done
-  deactivate WatchService

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -1,5 +1,5 @@
 export default {
-    logo: <img style={{"height": "30px"}} src="logo-dark.svg" />,
+    logo: <img style={{"height": "30px"}} src="/logo-dark.svg" />,
     project: {
       link: "https://github.com/utxorpc",
     },


### PR DESCRIPTION
# SUMMARY: 

- Relocated module sequence diagrams at the top of intro for interaction references.
- Fixed bug where UTxORPC logo doesn't show in other pages
- Cleaned up proper abbreviation of UTXOs to UTxOs
- Enhanced notes regarding reference to servers page
- Enhanced other details in docs

**FROM** 

<img width="1710" alt="Screenshot 2024-11-14 at 12 49 36 PM" src="https://github.com/user-attachments/assets/f68e8164-8cbe-4c20-b0d7-ffca9e9bee2b">

**TO**

<img width="1710" alt="Screenshot 2024-11-14 at 12 43 29 PM" src="https://github.com/user-attachments/assets/2a8a8a59-df82-48a7-b505-aa39d562318d">
